### PR TITLE
Package updates due to pandas_profiler breaking changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+core.Microsoft*
+core.mongo*
+core.python*
+env.py
+__pycache__/
+*.py[cod]
+node_modules/
+.github/
+cloudinary_python.txt
+kaggle.json

--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,0 +1,28 @@
+FROM gitpod/workspace-base:latest
+
+RUN echo "CI version from base"
+
+### Python ###
+USER gitpod
+RUN sudo install-packages python3-pip
+
+ENV PATH=$HOME/.pyenv/bin:$HOME/.pyenv/shims:$PATH
+RUN curl -fsSL https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && { echo; \
+    echo 'eval "$(pyenv init -)"'; \
+    echo 'eval "$(pyenv virtualenv-init -)"'; } >> /home/gitpod/.bashrc.d/60-python \
+    && pyenv update \
+    && pyenv install 3.8.12 \
+    && pyenv global 3.8.12 \
+    && python3 -m pip install --no-cache-dir --upgrade pip \
+    && python3 -m pip install --no-cache-dir --upgrade \
+    setuptools wheel virtualenv pipenv pylint rope flake8 \
+    mypy autopep8 pep8 pylama pydocstyle bandit notebook \
+    twine \
+    && sudo rm -rf /tmp/*USER gitpod
+ENV PYTHONUSERBASE=/workspace/.pip-modules \
+    PIP_USER=yes
+ENV PATH=$PYTHONUSERBASE/bin:$PATH
+
+# Setup Heroku CLI
+RUN curl https://cli-assets.heroku.com/install.sh | sh

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,6 @@
+image:
+  file: .gitpod.dockerfile
+
 tasks:
   - init: pip install -r requirements.txt
 
@@ -6,3 +9,9 @@ vscode:
   extensions:
     - ms-python.python
     - ms-toolsai.jupyter
+    - formulahendry.auto-close-tag
+    - eventyret.bootstrap-4-cdn-snippet
+    - hookyqr.beautify
+    - matt-rudge.auto-open-preview-panel
+    - ms-toolsai.jupyter-keymap
+    - ms-toolsai.jupyter-renderers

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-numpy==1.19.1
-pandas==1.1.2
+numpy==1.18.5
+pandas==1.4.2
 matplotlib==3.3.1
 seaborn==0.11.0
-pandas-profiling==2.11.0
+pandas-profiling==3.1.0
 plotly==4.12.0
 ppscore==1.2.0
 
@@ -13,3 +13,5 @@ imbalanced-learn==0.8.0
 scikit-learn==0.24.2
 xgboost==1.2.1
 yellowbrick==1.3
+Jinja2==3.1.1
+MarkupSafe==2.0.1


### PR DESCRIPTION
Pandas_profiler failed to run as it relied on an import of escape from jinja2. I had to update the version that imports from MarkupSafe. This necessitated some juggling of pandas and numpy versioning. Also, gitpod now uses Python 3.8.13, and all the videos state to use 3.8.12, so I added a dockerfile to load that version and upgrade pip. 